### PR TITLE
Add GCM API keys switcher, closing APNS streams after setting new PEM.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                         arrayNode("gcm")->
                             canBeUnset()->
                             children()->
-                                scalarNode("api_key")->isRequired()->cannotBeEmpty()->end()->
+                                scalarNode("api_key")->defaultValue("")->end()->
                                 booleanNode("use_multi_curl")->defaultValue(true)->end()->
                                 booleanNode("dry_run")->defaultFalse()->end()->
                             end()->

--- a/Service/Notifications.php
+++ b/Service/Notifications.php
@@ -4,6 +4,7 @@ namespace RMS\PushNotificationsBundle\Service;
 
 use RMS\PushNotificationsBundle\Device\Types;
 use RMS\PushNotificationsBundle\Message\MessageInterface;
+use RMS\PushNotificationsBundle\Service\OS\AndroidGCMNotification;
 use RMS\PushNotificationsBundle\Service\OS\AppleNotification;
 
 class Notifications
@@ -97,6 +98,21 @@ class Notifications
             /** @var AppleNotification $appleNotification */
             $appleNotification = $this->handlers[Types::OS_IOS];
             $appleNotification->setPemAsString($pemContent, $passphrase);
+        }
+    }
+
+    /**
+     * Set Android GCM API key.
+     * Service won't use api key passed by config anymore.
+     *
+     * @param string $apiKey
+     */
+    public function setGCMApiKey($apiKey)
+    {
+        if (isset($this->handlers[Types::OS_ANDROID_GCM]) && $this->handlers[Types::OS_ANDROID_GCM] instanceof AndroidGCMNotification) {
+            /** @var AndroidGCMNotification $androidGCMNotification */
+            $androidGCMNotification = $this->handlers[Types::OS_ANDROID_GCM];
+            $androidGCMNotification->setApiKey($apiKey);
         }
     }
 }

--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -168,4 +168,14 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
     {
         return $this->responses;
     }
+
+    /**
+     * Change Google GCM API key
+     *
+     * @param string $apiKey
+     */
+    public function setApiKey($apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
 }


### PR DESCRIPTION
- Add feature to use different Google GCM API keys in AndroidGCMNotification service.
- Close all APNS streams just after setting PEM as string.
